### PR TITLE
chore(pre-align): fill missing anchor ids on first h2 (10 docs)

### DIFF
--- a/en/console-guide/backup.md
+++ b/en/console-guide/backup.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=4afdece35cae -->
+<!-- pre-align:aligned sig=f821083285bb -->
 
 # Backup
 
@@ -8,6 +8,8 @@ You can prepare in advance to recover the cache in case of failure. You can perf
 
 !!! TIP "Note"
     Valkey creates an .rdb file when performing a backup. To restore using a created backup, it is recommended to use a cache with an engine version compatible with the backup.
+
+<a id="backup"></a>
 
 ## Backup
 

--- a/en/console-guide/cache.md
+++ b/en/console-guide/cache.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=63565fc6e53b -->
+<!-- pre-align:aligned sig=42b8b90f810e -->
+
+<a id="cache"></a>
 
 ## Cache
 

--- a/en/console-guide/db-security-group.md
+++ b/en/console-guide/db-security-group.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=2328c54fffa0 -->
+<!-- pre-align:aligned sig=a158e62f87ee -->
 
 # DB Security Group
 
@@ -15,6 +15,8 @@ Traffic with mismatched session states may be blocked.
 DB Security Group consists of a name, a description, and multiple DB security rules. The name of DB Security Group has the following constraints:
 
 * DB Security Group names can only contain between 1 and 100 uppercase and lowercase English letters, numbers, and certain symbols (-, \_, .). The first character must be an English letter.
+
+<a id="db-security-group"></a>
 
 ## DB Security Group
 

--- a/en/console-guide/event.md
+++ b/en/console-guide/event.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=9d9a4ba78df0 -->
+<!-- pre-align:aligned sig=db3db830ac83 -->
+
+<a id="event"></a>
 
 ## Event
 

--- a/en/console-guide/notification.md
+++ b/en/console-guide/notification.md
@@ -1,10 +1,12 @@
-<!-- pre-align:aligned sig=79fb5966bd1d -->
+<!-- pre-align:aligned sig=2bff6bc6a8a6 -->
 
 # Notification
 
 **Database > EasyCache > Console User Guide > Notification**
 
 You can receive notifications about performance metrics through notification groups. Select the **Notification Type** and **Enabled** status, then specify the node to monitor and the user group to receive notifications. Set the thresholds and conditions for performance metrics to receive notifications through the **Monitoring Settings**. When the set metrics meet the conditions in the Monitoring Settings, the associated user group will be notified. Notifications are sent via SMS or email, depending on the notification type set for the notification group.
+
+<a id="notification"></a>
 
 ## Notification
 

--- a/en/console-guide/parameter-group.md
+++ b/en/console-guide/parameter-group.md
@@ -1,10 +1,12 @@
-<!-- pre-align:aligned sig=6b3acffa6f47 -->
+<!-- pre-align:aligned sig=812393f54e66 -->
 
 # Parameter Group
 
 **Database > EasyCache > Console User Guide > Parameter Group**
 
 EasyCache provides a parameter group feature to apply Valkey (formerly Redis) settings installed on caches. A parameter group is a collection of parameters that can be used to configure Valkey. When the service is activated, a default parameter group is provided for each version of all engines. The default parameter group is provided as `{engine version name} Default` and consists of the recommended default parameter values for each version. The default parameter group can be modified or deleted in the same way as a regular parameter group.
+
+<a id="parameter-group"></a>
 
 ## Parameter Group
 

--- a/en/console-guide/server-dashboard.md
+++ b/en/console-guide/server-dashboard.md
@@ -1,4 +1,4 @@
-<!-- pre-align:aligned sig=610cfce5529f -->
+<!-- pre-align:aligned sig=87cf043e706f -->
 
 # Server Dashboard
 
@@ -13,6 +13,8 @@ Server Dashboard helps to visualize performance metrics on a chart. The charts a
 | 30 minutes   | 6 months   |
 | 2 hours   | 2 years    |
 | 1 day    | 5 years    |
+
+<a id="server-dashboard"></a>
 
 ## Server Dashboard
 

--- a/en/developer-guide.md
+++ b/en/developer-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=b7597aadf0a8 -->
+<!-- pre-align:aligned sig=6728d2d0abfe -->
+
+<a id="database-easycache-developer-guide"></a>
 
 ## Database > EasyCache > Developer Guide
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,8 +1,10 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=555eb5f183a2 -->
 
 # EasyCache Overview
 **Database > EasyCache > Overview**
 NHN Cloud EasyCache provides Valkey in the cloud environment. You can use an in-memory cache server with Valkey installed with simple settings.
+
+<a id="main-features"></a>
 
 ## Main features
 - Allows you to use a Valkey in-memory cache with the specifications you want.

--- a/en/release-notes.md
+++ b/en/release-notes.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=2c183bd2b2f1 -->
+<!-- pre-align:aligned sig=c5f4c2c6cf1e -->
+
+<a id="easycache-release-notes"></a>
 
 ## EasyCache Release Notes
 **Database > EasyCache > Release Notes**

--- a/ja/console-guide/backup.md
+++ b/ja/console-guide/backup.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=4afdece35cae -->
+<!-- pre-align:aligned sig=f821083285bb -->
+
+<a id="backup"></a>
 
 ## バックアップ
 

--- a/ja/console-guide/cache.md
+++ b/ja/console-guide/cache.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=63565fc6e53b -->
+<!-- pre-align:aligned sig=42b8b90f810e -->
+
+<a id="cache"></a>
 
 ## キャッシュ
 

--- a/ja/console-guide/db-security-group.md
+++ b/ja/console-guide/db-security-group.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=2328c54fffa0 -->
+<!-- pre-align:aligned sig=a158e62f87ee -->
+
+<a id="db-security-group"></a>
 
 ## DBセキュリティグループ
 

--- a/ja/console-guide/event.md
+++ b/ja/console-guide/event.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=9d9a4ba78df0 -->
+<!-- pre-align:aligned sig=db3db830ac83 -->
+
+<a id="event"></a>
 
 ## イベント
 

--- a/ja/console-guide/notification.md
+++ b/ja/console-guide/notification.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=79fb5966bd1d -->
+<!-- pre-align:aligned sig=2bff6bc6a8a6 -->
+
+<a id="notification"></a>
 
 ## 通知
 

--- a/ja/console-guide/parameter-group.md
+++ b/ja/console-guide/parameter-group.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=6b3acffa6f47 -->
+<!-- pre-align:aligned sig=812393f54e66 -->
+
+<a id="parameter-group"></a>
 
 ## パラメータグループ
 

--- a/ja/console-guide/server-dashboard.md
+++ b/ja/console-guide/server-dashboard.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=610cfce5529f -->
+<!-- pre-align:aligned sig=87cf043e706f -->
+
+<a id="server-dashboard"></a>
 
 ## サーバーダッシュボード
 

--- a/ja/developer-guide.md
+++ b/ja/developer-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=b7597aadf0a8 -->
+<!-- pre-align:aligned sig=6728d2d0abfe -->
+
+<a id="database-easycache-developer-guide"></a>
 
 ## Database > EasyCache > 開発者ガイド
 

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,8 +1,10 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=555eb5f183a2 -->
 
 # EasyCache 概要
 **Database > EasyCache > 概要**
 NHN Cloud EasyCache は、Valkey をクラウド環境で提供するサービスです。簡単な設定だけで、Valkey がインストールされたインメモリキャッシュサーバーを使用できます。
+
+<a id="main-features"></a>
 
 ## 主な機能
 - 希望のスペックの Valkey インメモリキャッシュを簡単に使用できます。

--- a/ja/release-notes.md
+++ b/ja/release-notes.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=2c183bd2b2f1 -->
+<!-- pre-align:aligned sig=c5f4c2c6cf1e -->
+
+<a id="easycache-release-notes"></a>
 
 ## EasyCacheリリースノート
 **Database > EasyCache > リリースノート**

--- a/ko/console-guide/backup.md
+++ b/ko/console-guide/backup.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=4afdece35cae -->
+<!-- pre-align:aligned sig=f821083285bb -->
+
+<a id="backup"></a>
 
 ## 백업
 

--- a/ko/console-guide/cache.md
+++ b/ko/console-guide/cache.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=63565fc6e53b -->
+<!-- pre-align:aligned sig=42b8b90f810e -->
+
+<a id="cache"></a>
 
 ## 캐시
 

--- a/ko/console-guide/db-security-group.md
+++ b/ko/console-guide/db-security-group.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=2328c54fffa0 -->
+<!-- pre-align:aligned sig=a158e62f87ee -->
+
+<a id="db-security-group"></a>
 
 ## DB 보안 그룹
 

--- a/ko/console-guide/event.md
+++ b/ko/console-guide/event.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=9d9a4ba78df0 -->
+<!-- pre-align:aligned sig=db3db830ac83 -->
+
+<a id="event"></a>
 
 ## 이벤트
 

--- a/ko/console-guide/notification.md
+++ b/ko/console-guide/notification.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=79fb5966bd1d -->
+<!-- pre-align:aligned sig=2bff6bc6a8a6 -->
+
+<a id="notification"></a>
 
 ## 알림
 

--- a/ko/console-guide/parameter-group.md
+++ b/ko/console-guide/parameter-group.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=6b3acffa6f47 -->
+<!-- pre-align:aligned sig=812393f54e66 -->
+
+<a id="parameter-group"></a>
 
 ## 파라미터 그룹
 

--- a/ko/console-guide/server-dashboard.md
+++ b/ko/console-guide/server-dashboard.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=610cfce5529f -->
+<!-- pre-align:aligned sig=87cf043e706f -->
+
+<a id="server-dashboard"></a>
 
 ## 서버 대시보드
 

--- a/ko/developer-guide.md
+++ b/ko/developer-guide.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=b7597aadf0a8 -->
+<!-- pre-align:aligned sig=6728d2d0abfe -->
+
+<a id="database-easycache-developer-guide"></a>
 
 ## Database > EasyCache > 개발자 가이드
 

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,8 +1,10 @@
-<!-- pre-align:aligned sig=ec416b7f4d48 -->
+<!-- pre-align:aligned sig=555eb5f183a2 -->
 
 # EasyCache 개요
 **Database > EasyCache > 개요**
 NHN Cloud EasyCache는 Valkey를 클라우드 환경에서 제공하는 서비스입니다. 간단한 설정만으로 Valkey가 설치된 인메모리 캐시 서버를 사용할 수 있습니다.
+
+<a id="main-features"></a>
 
 ## 주요 기능
 - 손쉽게 원하는 사양의 Valkey 인메모리 캐시를 사용할 수 있습니다.

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,4 +1,6 @@
-<!-- pre-align:aligned sig=2c183bd2b2f1 -->
+<!-- pre-align:aligned sig=c5f4c2c6cf1e -->
+
+<a id="easycache-release-notes"></a>
 
 ## EasyCache 릴리스 노트
 **Database > EasyCache > 릴리스 노트**


### PR DESCRIPTION
Manual, minimal-touch anchor-id fill on 10 docs whose first h2 had **no anchor id in any of ko/en/ja** on `alpha`. compare-headings flagged this as `id_diff` for every one of them (a h2..h4 heading without an anchor id is a mismatch), while the align tool's `pre-align:aligned` marker considered them aligned (ko/en/ja agreed on "no anchor") and skipped them — so `align-heading` never fixed it.

## Scope

Only id-less first-h2 headings are touched. No existing anchor is renamed. `{ #id }` inline attr blocks are **not** added (matches the surrounding files' block-style anchors). Body bytes, EOL style, and existing anchors are preserved verbatim; per file:

  * A new `<a id="<slug>"></a>` line inserted directly above the first h2 (h1 is skipped when present — `parse_units` ignores h1 so the anchor must sit above the first h2..h6 to bind).
  * The `<!-- pre-align:aligned sig=… -->` marker refreshed to the new outline hash so the next align run doesn't re-fire on these docs (verified: `has_valid_aligned_marker(text) == True` for every touched file post-change).

Slugs derived deterministically via `_slugify(en_heading_text)` (with the fixes from [cloud-translate#341](https://github.nhnent.com/TOASTCloud/cloud-translate/pull/341) applied), so a future `align-heading` run would produce the same result.

**`console-guide.md` intentionally omitted** — ko has no file at that path, en/ja do. That's an inter-lang **file existence** mismatch that this "id fill" task's scope doesn't cover; it needs a separate decision on whether to add a ko `console-guide.md` or remove the en/ja copies.

## Files touched (30 = 10 docs × ko/en/ja)

| Doc | slug |
| --- | --- |
| `overview.md` | `main-features` |
| `developer-guide.md` | `database-easycache-developer-guide` |
| `release-notes.md` | `easycache-release-notes` |
| `console-guide/backup.md` | `backup` |
| `console-guide/cache.md` | `cache` |
| `console-guide/db-security-group.md` | `db-security-group` |
| `console-guide/event.md` | `event` |
| `console-guide/notification.md` | `notification` |
| `console-guide/parameter-group.md` | `parameter-group` |
| `console-guide/server-dashboard.md` | `server-dashboard` |

Every file's diff is `+3 / -1` (add anchor + blank + refreshed marker; remove old marker).

## Verification

Post-change, on every one of the 30 files:

  * `align_apply.has_valid_aligned_marker(text) == True` (marker sig now matches the new outline).
  * `compare_headings.compare_doc(...)` returns **0 diffs** for both `en` and `ja` legs on all 10 docs.
  * No existing anchor id collisions — the proposed slugs are unique within each doc.

## Heading compare (docs viewer)

- **Base (`alpha`)**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2Feasycache%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **This PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2Feasycache%2Fpull%2FNEW&source=ko&langs=en%2Cja)